### PR TITLE
fix: [Android] Fixed bounds to coords conversion

### DIFF
--- a/core/src/main/kotlin/driver/mobile/AndroidAppiumDriver.kt
+++ b/core/src/main/kotlin/driver/mobile/AndroidAppiumDriver.kt
@@ -398,7 +398,7 @@ class AndroidAppiumDriver : Driver {
         val x1y1x2y2 = bounds.substring(1, bounds.length - 1).split("][")
 
         val x1y1 = x1y1x2y2[0].split(",")
-        val x2y2 = x1y1x2y2[0].split(",")
+        val x2y2 = x1y1x2y2[1].split(",")
 
         val x1 = x1y1[0].toInt()
         val y1 = x1y1[1].toInt()


### PR DESCRIPTION
This error resulted in the loss of element size data when converting bounds to coords. In some situations, the scroll size calculation could be incorrect and because of this, a long screenshot could be merged incorrectly.